### PR TITLE
feat: create basic tile map

### DIFF
--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -1,11 +1,181 @@
-[gd_scene load_steps=4 format=3 uid="uid://dpfox4au6w3o3"]
+[gd_scene load_steps=6 format=4 uid="uid://dpfox4au6w3o3"]
 
+[ext_resource type="Texture2D" uid="uid://bvop5vl087ibq" path="res://assets/sprites/world_tileset.png" id="1_88ist"]
 [ext_resource type="PackedScene" uid="uid://gbaaqcleq0ms" path="res://scenes/player.tscn" id="1_wccxc"]
 [ext_resource type="Script" path="res://scripts/player.gd" id="2_mskbq"]
 
-[sub_resource type="WorldBoundaryShape2D" id="WorldBoundaryShape2D_bh3r8"]
+[sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_bxbhc"]
+texture = ExtResource("1_88ist")
+0:0/0 = 0
+0:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+1:0/0 = 0
+1:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+2:0/0 = 0
+2:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+3:0/0 = 0
+3:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+4:0/0 = 0
+4:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+5:0/0 = 0
+5:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+6:0/0 = 0
+6:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, 8, -8, -8, 8, -8, 8, 8)
+7:0/0 = 0
+7:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+8:0/0 = 0
+8:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+9:0/0 = 0
+9:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -5.5, 8, 0.25, -8, -1.625)
+10:0/0 = 0
+10:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -5.375, 8, -5.5, 8, 0.25, -8, 0.25)
+11:0/0 = 0
+11:0/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -5.375, 8, -8, 8, -1.67938, -8, 0.25)
+0:1/0 = 0
+0:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+1:1/0 = 0
+1:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+2:1/0 = 0
+2:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+3:1/0 = 0
+3:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+4:1/0 = 0
+4:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+5:1/0 = 0
+5:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+6:1/0 = 0
+6:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+7:1/0 = 0
+7:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+8:1/0 = 0
+8:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+9:1/0 = 0
+9:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -5.5, 8, 0.25, -8, -1.625)
+10:1/0 = 0
+10:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -5.375, 8, -5.5, 8, 0.25, -8, 0.25)
+11:1/0 = 0
+11:1/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -5.375, 8, -8, 8, -1.67938, -8, 0.25)
+0:2/0 = 0
+0:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+1:2/0 = 0
+1:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+2:2/0 = 0
+2:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+3:2/0 = 0
+3:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+4:2/0 = 0
+4:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+5:2/0 = 0
+5:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+6:2/0 = 0
+6:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+7:2/0 = 0
+7:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+8:2/0 = 0
+8:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+9:2/0 = 0
+9:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -5.5, 8, 0.25, -8, -1.625)
+10:2/0 = 0
+10:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -5.375, 8, -5.5, 8, 0.25, -8, 0.25)
+11:2/0 = 0
+11:2/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -5.375, 8, -8, 8, -1.67938, -8, 0.25)
+0:3/0 = 0
+1:3/0 = 0
+2:3/0 = 0
+2:3/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+5:3/0 = 0
+6:3/0 = 0
+7:3/0 = 0
+7:3/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+8:3/0 = 0
+9:3/0 = 0
+0:4/0 = 0
+1:4/0 = 0
+5:4/0 = 0
+6:4/0 = 0
+7:4/0 = 0
+7:4/0/physics_layer_0/polygon_0/points = PackedVector2Array(-8, -8, 8, -8, 8, 8, -8, 8)
+8:4/0 = 0
+9:4/0 = 0
+0:5/0 = 0
+1:5/0 = 0
+5:5/0 = 0
+6:5/0 = 0
+7:5/0 = 0
+8:5/0 = 0
+1:6/0 = 0
+5:6/0 = 0
+6:6/0 = 0
+7:6/0 = 0
+8:6/0 = 0
+0:7/0 = 0
+1:7/0 = 0
+3:7/0 = 0
+5:7/0 = 0
+6:7/0 = 0
+7:7/0 = 0
+8:7/0 = 0
+0:8/0 = 0
+1:8/0 = 0
+2:8/0 = 0
+3:8/0 = 0
+4:8/0 = 0
+5:8/0 = 0
+6:8/0 = 0
+7:8/0 = 0
+8:8/0 = 0
+0:9/0 = 0
+1:9/0 = 0
+2:9/0 = 0
+3:9/0 = 0
+4:9/0 = 0
+5:9/0 = 0
+6:9/0 = 0
+7:9/0 = 0
+0:10/0 = 0
+1:10/0 = 0
+2:10/0 = 0
+3:10/0 = 0
+4:10/0 = 0
+6:10/0 = 0
+0:11/0 = 0
+1:11/0 = 0
+2:11/0 = 0
+3:11/0 = 0
+4:11/0 = 0
+5:11/0 = 0
+0:12/0 = 0
+1:12/0 = 0
+2:12/0 = 0
+3:12/0 = 0
+4:12/0 = 0
+0:13/0 = 0
+1:13/0 = 0
+2:13/0 = 0
+3:13/0 = 0
+4:13/0 = 0
+5:13/0 = 0
+0:14/0 = 0
+1:14/0 = 0
+2:14/0 = 0
+3:14/0 = 0
+4:14/0 = 0
+0:15/0 = 0
+1:15/0 = 0
+2:15/0 = 0
+3:15/0 = 0
+2:4/size_in_atlas = Vector2i(3, 3)
+2:4/0 = 0
+
+[sub_resource type="TileSet" id="TileSet_i2km1"]
+physics_layer_0/collision_layer = 1
+sources/0 = SubResource("TileSetAtlasSource_bxbhc")
 
 [node name="Game" type="Node2D"]
+
+[node name="TileMap" type="TileMapLayer" parent="."]
+use_parent_material = true
+tile_map_data = PackedByteArray("AAAAAAAAAAAAAAAAAAD//wAAAAAAAAAAAAAAAAEAAAAAAAEAAAD//wEAAAAAAAEAAAD//wIAAAAAAAEAAAAAAAIAAAAAAAEAAAD//wMAAAAAAAEAAAD//wQAAAAAAAEAAAAAAAQAAAAAAAEAAAD+/wMAAAAAAAEAAAD9/wMAAAAAAAEAAAD9/wQAAAAAAAEAAAD+/wIAAAAAAAAAAAD9/wIAAAAAAAAAAAABAAIAAAAGAAAAAAACAAIAAAAGAAAAAAADAAIAAAAGAAAAAAABAAMAAAAGAAEAAAACAAMAAAAIAAAAAAACAAQAAAAGAAEAAAADAAQAAAAGAAEAAAABAAQAAAAGAAEAAAADAAMAAAAGAAEAAAD+/wQAAAABAAEAAAAAAAMAAAABAAAAAAACAPz/AAAAAAAAAAACAP3/AAAAAAEAAAAEAP3/AAAAAAEAAAAEAPz/AAAAAAEAAAADAPz/AAAAAAEAAAAFAP7/AAAAAAEAAAAGAP7/AAAAAAEAAAAJAP7/AAAAAAEAAAALAP7/AAAAAAEAAAAMAP7/AAAAAAEAAAAKAP3/AAAAAAEAAAALAP3/AAAAAAEAAAANAP//AAAEAAEAAAAOAP//AAAEAAEAAAAPAP//AAAEAAEAAAAPAAAAAAAEAAEAAAAQAAAAAAAEAAEAAAAQAAEAAAAEAAEAAAARAAEAAAAEAAEAAAASAAEAAAAEAAEAAAATAAEAAAAEAAEAAAATAAIAAAAEAAEAAAASAAIAAAAEAAEAAAASAAMAAAAEAAEAAAASAAQAAAAEAAEAAAATAAQAAAAEAAEAAAATAAMAAAAFAAAAAAAQAP//AAAFAAAAAAARAAAAAAAFAAEAAAATAAAAAAAEAAAAAAASAAAAAAAEAAAAAAAPAP7/AAAEAAAAAAAOAP7/AAAEAAAAAAANAP7/AAAEAAAAAAAKAP7/AAABAAEAAAADAP3/AAABAAAAAAAEAPv/AAAAAAAAAAADAPv/AAAAAAAAAAAKAPz/AAAAAAAAAAALAPz/AAAAAAAAAAAFAP3/AAAAAAAAAAAGAP3/AAAAAAAAAAAJAP3/AAAAAAAAAAAMAP3/AAAAAAAAAAAHAP3/AAAJAAAAAAAIAP3/AAALAAAAAAAEAAIAAAAJAAAAAAAFAAIAAAAKAAAAAAALAAIAAAAGAAAAAAALAAMAAAAGAAEAAAALAAQAAAAGAAEAAAAIAAIAAAAGAAAAAAAIAAMAAAAGAAEAAAAIAAQAAAAGAAEAAAAMAAIAAAAGAAAAAAAMAAMAAAAIAAEAAAAMAAQAAAAGAAEAAAAHAAIAAAAGAAAAAAAHAAMAAAAGAAEAAAAHAAQAAAAGAAEAAAAGAAIAAAALAAAAAAD+/wEAAAABAAAAAAAGAPz/AAAAAAUAAAAGAPv/AAAAAAQAAAAGAPr/AAAAAAQAAAAGAPn/AAAAAAMAAAAOAP3/AAAIAAYAAAARAP//AAAFAAcAAAAHAAEAAAAAAAgAAAD9/wEAAAABAAYAAAAPAP3/AAAFAAUAAAAPAPz/AAAFAAQAAAAPAPv/AAAFAAMAAAAaAAEAAAACAAEAAAAaAAIAAAACAAEAAAAaAAMAAAADAAEAAAAaAAQAAAACAAEAAAAbAAEAAAADAAAAAAAbAAIAAAACAAEAAAAbAAMAAAACAAEAAAAbAAQAAAACAAEAAAAcAAIAAAADAAEAAAAcAAMAAAACAAEAAAAcAAQAAAACAAEAAAAdAAMAAAACAAEAAAAdAAQAAAACAAEAAAAaAAAAAAACAAIAAAAbAAAAAAACAAAAAAAcAAEAAAAGAAcAAAAdAAIAAAACAAEAAAA=")
+tile_set = SubResource("TileSet_i2km1")
 
 [node name="Player" parent="." instance=ExtResource("1_wccxc")]
 position = Vector2(0, -2)
@@ -15,8 +185,3 @@ script = ExtResource("2_mskbq")
 position = Vector2(0, -8)
 zoom = Vector2(4, 4)
 position_smoothing_enabled = true
-
-[node name="Ground" type="StaticBody2D" parent="."]
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Ground"]
-shape = SubResource("WorldBoundaryShape2D_bh3r8")


### PR DESCRIPTION
### TL;DR
Added tilemap system with collision detection to replace basic ground collision

### What changed?
- Integrated a new world tileset with physics-based collision polygons
- Implemented a TileMap system with predefined tile configurations
- Removed the simple StaticBody2D ground collision
- Added tile data for the game world layout

