### PR TITLE
feat: create basic slime enemy

### DIFF
--- a/scenes/game.tscn
+++ b/scenes/game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=4 uid="uid://dpfox4au6w3o3"]
+[gd_scene load_steps=16 format=4 uid="uid://dpfox4au6w3o3"]
 
 [ext_resource type="Texture2D" uid="uid://bvop5vl087ibq" path="res://assets/sprites/world_tileset.png" id="1_88ist"]
 [ext_resource type="PackedScene" uid="uid://gbaaqcleq0ms" path="res://scenes/player.tscn" id="1_wccxc"]
@@ -6,6 +6,7 @@
 [ext_resource type="PackedScene" uid="uid://qoi4ox7vv8xi" path="res://scenes/platform.tscn" id="4_elaoi"]
 [ext_resource type="PackedScene" uid="uid://cylx1g2fqjcrm" path="res://scenes/coin.tscn" id="5_8qv7g"]
 [ext_resource type="PackedScene" uid="uid://dun067imjeu7w" path="res://scenes/killzone.tscn" id="6_e3snp"]
+[ext_resource type="PackedScene" uid="uid://bttxymbomgrvf" path="res://scenes/slime.tscn" id="7_ixe31"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_bk5ok"]
 texture = ExtResource("1_88ist")
@@ -342,7 +343,7 @@ _data = {
 
 [node name="Game" type="Node2D"]
 
-[node name="TileMap" type="Node" parent="."]
+[node name="TileMap" type="Node2D" parent="."]
 
 [node name="Background" type="TileMapLayer" parent="TileMap"]
 z_index = -1
@@ -364,9 +365,9 @@ limit_bottom = 80
 limit_smoothed = true
 position_smoothing_enabled = true
 
-[node name="Killzone" parent="." instance=ExtResource("6_e3snp")]
+[node name="Fallzone" parent="." instance=ExtResource("6_e3snp")]
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Killzone"]
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Fallzone"]
 shape = SubResource("WorldBoundaryShape2D_nqfu7")
 
 [node name="Platforms" type="Node2D" parent="."]
@@ -411,3 +412,8 @@ position = Vector2(737, -71)
 
 [node name="Coin8" parent="Coins" instance=ExtResource("5_8qv7g")]
 position = Vector2(756, -71)
+
+[node name="Enemies" type="Node2D" parent="."]
+
+[node name="Slime" parent="Enemies" instance=ExtResource("7_ixe31")]
+position = Vector2(496, 32)

--- a/scenes/slime.tscn
+++ b/scenes/slime.tscn
@@ -1,0 +1,71 @@
+[gd_scene load_steps=10 format=3 uid="uid://bttxymbomgrvf"]
+
+[ext_resource type="Texture2D" uid="uid://cle273q8j4ooh" path="res://assets/sprites/slime_green.png" id="1_is8ql"]
+[ext_resource type="Script" path="res://scripts/slime.gd" id="1_x220t"]
+[ext_resource type="PackedScene" uid="uid://dun067imjeu7w" path="res://scenes/killzone.tscn" id="2_eyfpr"]
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_26j3l"]
+atlas = ExtResource("1_is8ql")
+region = Rect2(0, 24, 24, 24)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_jk11j"]
+atlas = ExtResource("1_is8ql")
+region = Rect2(24, 24, 24, 24)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_f65ay"]
+atlas = ExtResource("1_is8ql")
+region = Rect2(48, 24, 24, 24)
+
+[sub_resource type="AtlasTexture" id="AtlasTexture_wxixh"]
+atlas = ExtResource("1_is8ql")
+region = Rect2(72, 24, 24, 24)
+
+[sub_resource type="SpriteFrames" id="SpriteFrames_jvfoy"]
+animations = [{
+"frames": [{
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_26j3l")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_jk11j")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_f65ay")
+}, {
+"duration": 1.0,
+"texture": SubResource("AtlasTexture_wxixh")
+}],
+"loop": true,
+"name": &"idle",
+"speed": 10.0
+}]
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_7yepv"]
+size = Vector2(10, 11.5)
+
+[node name="Slime" type="Node2D"]
+script = ExtResource("1_x220t")
+
+[node name="AnimatedSprite2D" type="AnimatedSprite2D" parent="."]
+position = Vector2(0, -12)
+sprite_frames = SubResource("SpriteFrames_jvfoy")
+animation = &"idle"
+autoplay = "idle"
+frame = 1
+frame_progress = 0.17876
+
+[node name="Killzone" parent="." instance=ExtResource("2_eyfpr")]
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="Killzone"]
+position = Vector2(0, -6.75)
+shape = SubResource("RectangleShape2D_7yepv")
+
+[node name="Sight" type="Node2D" parent="."]
+
+[node name="RayCast2DLeft" type="RayCast2D" parent="Sight"]
+position = Vector2(0, -6)
+target_position = Vector2(-10, 0)
+
+[node name="RayCast2DRight" type="RayCast2D" parent="Sight"]
+position = Vector2(0, -6)
+target_position = Vector2(10, 0)

--- a/scripts/slime.gd
+++ b/scripts/slime.gd
@@ -1,0 +1,19 @@
+extends Node2D
+
+@export var speed := 60.0
+var direction := 1
+
+@onready var sprite: AnimatedSprite2D = $AnimatedSprite2D
+@onready var raycast_right: RayCast2D = $Sight/RayCast2DRight
+@onready var raycast_left: RayCast2D = $Sight/RayCast2DLeft
+
+func _process(delta: float) -> void:
+	if raycast_right.is_colliding():
+		direction = -1
+		sprite.flip_h = true
+
+	if raycast_left.is_colliding():
+		direction = 1
+		sprite.flip_h = false
+
+	position.x += direction * speed * delta


### PR DESCRIPTION
### TL;DR
Added a new slime enemy that patrols platforms and can kill the player on contact.

### What changed?
- Created a new slime enemy scene with animated sprites and collision detection
- Added raycasts for platform edge detection
- Implemented basic movement logic for the slime to patrol back and forth
- Integrated the slime enemy into the main game scene
- Renamed "Killzone" to "Fallzone" in the game scene for clarity

