### PR TITLE
feat: create basic death sequence for player

### DIFF
--- a/scripts/killzone.gd
+++ b/scripts/killzone.gd
@@ -2,9 +2,12 @@ extends Area2D
 
 @onready var timer := $Timer
 
-func _on_body_entered(_body:Node2D) -> void:
+func _on_body_entered(body:Node2D) -> void:
+	Engine.time_scale = 0.5
+	body.get_node("CollisionShape2D").queue_free()
 	timer.start()
 
 
 func _on_timer_timeout() -> void:
+	Engine.time_scale = 1
 	get_tree().reload_current_scene()


### PR DESCRIPTION
### TL;DR
Added slow motion effect when player dies and disabled collision before scene reload

### What changed?
- Added slow motion by setting Engine.time_scale to 0.5 when entering killzone
- Disabled the player's collision shape before scene reload
- Restored normal time scale when reloading scene
