### PR TITLE
feat: play sound for coin pickup

### DIFF
--- a/default_bus_layout.tres
+++ b/default_bus_layout.tres
@@ -1,0 +1,9 @@
+[gd_resource type="AudioBusLayout" format=3 uid="uid://cx3d55e5swqwk"]
+
+[resource]
+bus/1/name = &"SFX"
+bus/1/solo = false
+bus/1/mute = false
+bus/1/bypass_fx = false
+bus/1/volume_db = -11.952
+bus/1/send = &"Master"

--- a/scenes/coin.tscn
+++ b/scenes/coin.tscn
@@ -1,7 +1,8 @@
-[gd_scene load_steps=17 format=3 uid="uid://cylx1g2fqjcrm"]
+[gd_scene load_steps=21 format=3 uid="uid://cylx1g2fqjcrm"]
 
 [ext_resource type="Script" path="res://scripts/coin.gd" id="1_68kay"]
 [ext_resource type="Texture2D" uid="uid://brt68swukbeka" path="res://assets/sprites/coin.png" id="1_nwjf5"]
+[ext_resource type="AudioStream" uid="uid://cxrfa2coygdqn" path="res://assets/sounds/coin.wav" id="3_hol1b"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_k087x"]
 atlas = ExtResource("1_nwjf5")
@@ -98,6 +99,104 @@ animations = [{
 [sub_resource type="CircleShape2D" id="CircleShape2D_aqdk1"]
 radius = 5.0
 
+[sub_resource type="Animation" id="Animation_t0wy5"]
+resource_name = "pickup"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("AnimatedSprite2D:visible")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("CollisionShape2D:disabled")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("AudioStreamPlayer2D:playing")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0, 0.0001),
+"transitions": PackedFloat32Array(1, 1),
+"update": 1,
+"values": [true, true]
+}
+tracks/3/type = "method"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath(".")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"times": PackedFloat32Array(0.933333),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"queue_free"
+}]
+}
+
+[sub_resource type="Animation" id="Animation_2f0ni"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("AnimatedSprite2D:visible")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("CollisionShape2D:disabled")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+tracks/2/type = "value"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("AudioStreamPlayer2D:playing")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_bjyi4"]
+_data = {
+"RESET": SubResource("Animation_2f0ni"),
+"pickup": SubResource("Animation_t0wy5")
+}
+
 [node name="Coin" type="Area2D"]
 collision_mask = 2
 script = ExtResource("1_68kay")
@@ -108,5 +207,14 @@ autoplay = "default"
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource("CircleShape2D_aqdk1")
+
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="."]
+stream = ExtResource("3_hol1b")
+bus = &"SFX"
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_bjyi4")
+}
 
 [connection signal="body_entered" from="." to="." method="_on_body_entered"]

--- a/scripts/coin.gd
+++ b/scripts/coin.gd
@@ -4,6 +4,8 @@ extends Area2D
 
 signal collected
 
+@onready var animation : AnimationPlayer = $AnimationPlayer
+
 func _on_body_entered(_body:Node2D) -> void:
 	collected.emit()
-	queue_free()
+	animation.play("pickup")


### PR DESCRIPTION
### TL;DR
Added coin collection sound effect and animation when picking up coins

### What changed?
- Created a new audio bus for sound effects
- Added coin pickup sound effect
- Implemented animation sequence for coin collection that:
  - Hides the coin sprite
  - Disables collision
  - Plays sound effect
  - Queues coin for deletion after animation completes

