### PR TITLE
feat: play sound on player jump

### DIFF
--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=25 format=3 uid="uid://gbaaqcleq0ms"]
+[gd_scene load_steps=26 format=3 uid="uid://gbaaqcleq0ms"]
 
 [ext_resource type="Texture2D" uid="uid://bsf4r571aatmg" path="res://assets/sprites/knight.png" id="1_kfn8i"]
+[ext_resource type="AudioStream" uid="uid://cwg1jqg6okbh3" path="res://assets/sounds/jump.wav" id="2_r4thu"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_syg5i"]
 atlas = ExtResource("1_kfn8i")
@@ -183,3 +184,8 @@ autoplay = "idle"
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(0, -6)
 shape = SubResource("CircleShape2D_iye48")
+
+[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="."]
+stream = ExtResource("2_r4thu")
+volume_db = -5.0
+bus = &"SFX"

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -4,6 +4,7 @@ extends CharacterBody2D
 
 
 @onready var sprite: AnimatedSprite2D = $AnimatedSprite2D
+@onready var jump_sound: AudioStreamPlayer2D = $AudioStreamPlayer2D
 
 const SPEED = 130.0
 const JUMP_VELOCITY = -300.0
@@ -17,6 +18,8 @@ func _physics_process(delta: float) -> void:
 	# Handle jump.
 	if Input.is_action_just_pressed("jump") and is_on_floor():
 		velocity.y = JUMP_VELOCITY
+		if is_on_floor():
+			jump_sound.play()
 
   # Get the input direction: -1, 0, 1
 	var direction := Input.get_axis("move_left", "move_right")


### PR DESCRIPTION
### TL;DR
Added jump sound effect to player character

### What changed?
- Added a new audio stream player to the player scene
- Connected jump sound effect asset
- Configured audio settings with -5.0 volume on SFX bus
- Added logic to play jump sound when player performs a jump action while on the floor

