### PR TITLE
feat: play sound on player death

### DIFF
--- a/scenes/player.tscn
+++ b/scenes/player.tscn
@@ -1,6 +1,7 @@
-[gd_scene load_steps=26 format=3 uid="uid://gbaaqcleq0ms"]
+[gd_scene load_steps=31 format=3 uid="uid://gbaaqcleq0ms"]
 
 [ext_resource type="Texture2D" uid="uid://bsf4r571aatmg" path="res://assets/sprites/knight.png" id="1_kfn8i"]
+[ext_resource type="AudioStream" uid="uid://dg23cpiew3sic" path="res://assets/sounds/hurt.wav" id="2_7si6u"]
 [ext_resource type="AudioStream" uid="uid://cwg1jqg6okbh3" path="res://assets/sounds/jump.wav" id="2_r4thu"]
 
 [sub_resource type="AtlasTexture" id="AtlasTexture_syg5i"]
@@ -171,6 +172,86 @@ animations = [{
 [sub_resource type="CircleShape2D" id="CircleShape2D_iye48"]
 radius = 5.0
 
+[sub_resource type="Animation" id="Animation_o81hj"]
+length = 0.001
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("SFX/hurt:playing")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("SFX/Jump:playing")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [false]
+}
+
+[sub_resource type="Animation" id="Animation_olvsc"]
+resource_name = "jump"
+length = 0.3
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("SFX/Jump:playing")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+
+[sub_resource type="Animation" id="Animation_qsmp4"]
+resource_name = "die"
+length = 0.3
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("SFX/hurt:playing")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0),
+"transitions": PackedFloat32Array(1),
+"update": 1,
+"values": [true]
+}
+tracks/1/type = "method"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("CollisionShape2D")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0.0333333),
+"transitions": PackedFloat32Array(1),
+"values": [{
+"args": [],
+"method": &"queue_free"
+}]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_00cdb"]
+_data = {
+"RESET": SubResource("Animation_o81hj"),
+"die": SubResource("Animation_qsmp4"),
+"jump": SubResource("Animation_olvsc")
+}
+
 [node name="Player" type="CharacterBody2D"]
 z_index = 5
 collision_layer = 2
@@ -185,7 +266,19 @@ autoplay = "idle"
 position = Vector2(0, -6)
 shape = SubResource("CircleShape2D_iye48")
 
-[node name="AudioStreamPlayer2D" type="AudioStreamPlayer2D" parent="."]
+[node name="SFX" type="Node2D" parent="."]
+
+[node name="Jump" type="AudioStreamPlayer2D" parent="SFX"]
 stream = ExtResource("2_r4thu")
 volume_db = -5.0
 bus = &"SFX"
+
+[node name="hurt" type="AudioStreamPlayer2D" parent="SFX"]
+stream = ExtResource("2_7si6u")
+volume_db = -5.0
+bus = &"SFX"
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_00cdb")
+}

--- a/scripts/game.gd
+++ b/scripts/game.gd
@@ -17,6 +17,3 @@ func _ready() -> void:
 func collect_coin() -> void:
 	score += 1
 	score_label.text = "You collected %d coins" % score
-
-
-

--- a/scripts/killzone.gd
+++ b/scripts/killzone.gd
@@ -6,7 +6,7 @@ extends Area2D
 
 func _on_body_entered(body:Node2D) -> void:
 	Engine.time_scale = 0.5
-	body.get_node("CollisionShape2D").queue_free()
+	body.get_node("AnimationPlayer").play("die")
 	timer.start()
 
 

--- a/scripts/player.gd
+++ b/scripts/player.gd
@@ -4,7 +4,7 @@ extends CharacterBody2D
 
 
 @onready var sprite: AnimatedSprite2D = $AnimatedSprite2D
-@onready var jump_sound: AudioStreamPlayer2D = $AudioStreamPlayer2D
+@onready var animation: AnimationPlayer = $AnimationPlayer
 
 const SPEED = 130.0
 const JUMP_VELOCITY = -300.0
@@ -18,8 +18,8 @@ func _physics_process(delta: float) -> void:
 	# Handle jump.
 	if Input.is_action_just_pressed("jump") and is_on_floor():
 		velocity.y = JUMP_VELOCITY
-		if is_on_floor():
-			jump_sound.play()
+		if not animation.is_playing():
+			animation.play("jump")
 
   # Get the input direction: -1, 0, 1
 	var direction := Input.get_axis("move_left", "move_right")


### PR DESCRIPTION
### TL;DR
Added death and jump animations with corresponding sound effects for the player character.

### What changed?
- Added a hurt sound effect for player death
- Created new animations for jump and death sequences
- Reorganized audio nodes under a dedicated SFX node
- Modified killzone to trigger death animation instead of directly removing collision
- Updated jump sound trigger to use animation player

